### PR TITLE
Fix: add double token in authorization header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ tmp
 
 coverage.html
 coverage.out
+.vscode

--- a/internal/server/handlerCategory.go
+++ b/internal/server/handlerCategory.go
@@ -46,14 +46,16 @@ func _categoryHandler(s *shared, req *http.Request, res *response) (*response, *
 
 	var config k8s.KubeConfig
 	if data.ProjectName != "" && data.WorkspaceName != "" && data.McpName != "" {
-		config, err = openmcp.GetControlPlaneKubeconfig(s.crateKube, data.ProjectName, data.WorkspaceName, data.McpName, data.Authorization, crateKubeconfig)
+		config, err = openmcp.GetControlPlaneKubeconfig(s.crateKube, data.ProjectName, data.WorkspaceName, data.McpName, data.CrateAuthorizationToken, crateKubeconfig)
 		if err != nil {
 			slog.Error("failed to get control plane api config", "err", err)
 			return nil, NewInternalServerError("failed to get control plane api config")
 		}
-		if data.Authorization != "" {
-			config.SetUserToken(data.Authorization)
+		if data.McpAuthorizationToken == "" {
+			slog.Error("MCP authorization token not provided")
+			return nil, NewBadRequestError("MCP authorization token not provided")
 		}
+		config.SetUserToken(data.McpAuthorizationToken)
 	} else {
 		slog.Error("either use %s: true or provide %s, %s and %s headers", useCrateClusterHeader, projectNameHeader, workspaceNameHeader, mcpName)
 		return nil, NewBadRequestError(

--- a/internal/server/utils.go
+++ b/internal/server/utils.go
@@ -3,6 +3,7 @@ package server
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -102,4 +103,22 @@ func ParseJQ(inputJson []byte, inputJQ string) (string, error) {
 	}
 
 	return strings.Join(result[:], "\n"), nil
+}
+
+// parseAuthorizationHeaderWithDoubleTokens parses an authorization header that may contain two tokens separated by a comma.
+// It returns the first token and the second token (if present). If the second token is absent, it returns an empty string for it.
+// If the header is empty or contains more than two tokens, it returns an error.
+func parseAuthorizationHeaderWithDoubleTokens(authHeader string) (string, string, error) {
+	if authHeader == "" {
+		return "", "", fmt.Errorf("authorization header is empty")
+	}
+
+	tokens := strings.Split(authHeader, ",")
+	if len(tokens) > 2 {
+		return "", "", fmt.Errorf("authorization header must contain two or less tokens separated by a space")
+	}
+	if len(tokens) == 1 {
+		return tokens[0], "", nil
+	}
+	return tokens[0], tokens[1], nil
 }

--- a/internal/server/utils_test.go
+++ b/internal/server/utils_test.go
@@ -1,0 +1,41 @@
+package server
+
+import (
+	"testing"
+)
+
+func TestParseAuthorizationHeaderWithDoubleTokens(t *testing.T) {
+	tests := []struct {
+		authHeader string
+		token1     string
+		token2     string
+		expectErr  bool
+	}{
+		{"token1,token2", "token1", "token2", false},
+		{"token1", "token1", "", false},
+		{"", "", "", true},
+		{"token1,token2,token3", "", "", true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.authHeader, func(t *testing.T) {
+			token1, token2, err := parseAuthorizationHeaderWithDoubleTokens(test.authHeader)
+
+			if test.expectErr {
+				if err == nil {
+					t.Errorf("expected an error but got none")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("expected no error but got: %v", err)
+				}
+				if token1 != test.token1 {
+					t.Errorf("expected token1 to be %q but got %q", test.token1, token1)
+				}
+				if token2 != test.token2 {
+					t.Errorf("expected token2 to be %q but got %q", test.token2, token2)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR reintroduces two possible auth tokens that have been removed in #6 . To follow the strategy of only adding auth tokens in the Authorization header, this assumes two auth token to be comma separated.

It is possible to have only one token (for requests against the crate) or two tokens (for requests against an mcp - that also requires a request against the mcp). More are not accepted.

This seems to violate the RFC defining http headers and the auth header to only be a single value but since this is not a public api it is acceptable with the added advantage of using the standard authorization header over a custom header.

**Needs to be merged together with https://github.com/openmcp-project/ui-frontend/pull/142**