### PR TITLE
fix: add additional prohibited request headers to prevent forwarding …

### DIFF
--- a/internal/server/handlerMain.go
+++ b/internal/server/handlerMain.go
@@ -37,6 +37,17 @@ var prohibitedRequestHeaders = []string{
 	authorizationHeader,
 	"User-Agent",
 	"Host",
+	// HTTP hop-by-hop headers that should not be forwarded to downstream services
+	"Accept-Encoding",
+	"Content-Encoding",
+	"Transfer-Encoding",
+	"Connection",
+	"Keep-Alive",
+	"Upgrade",
+	"TE",
+	"Trailer",
+	"Proxy-Authorization",
+	"Proxy-Authenticate",
 }
 
 type ExtractedRequestData struct {


### PR DESCRIPTION
This PR prevents sending some transport headers to the underlying kubernetes API which causes some weird encoding issues in a collection request like `/managed`.

See also: https://github.com/openmcp-project/ui-frontend/pull/381 (frontend)