### PR TITLE
fix: run container as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,8 @@ WORKDIR /
 COPY --from=build /bin/app /bin/app
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
+USER 65532:65532
+
 EXPOSE 3000
 
 ENTRYPOINT ["/bin/app"]


### PR DESCRIPTION
## Summary
- Add `USER 65532:65532` to the deploy stage of the Dockerfile
- With `FROM scratch` there is no `/etc/passwd`, so a numeric UID is used
- Ensures the container does not run as root

## Test plan
- [ ] Verify the image builds successfully
- [ ] Verify the container runs as UID 65532
- [ ] Verify the app serves correctly on port 3000