### PR TITLE
fix: remove dead ParseJsonPath function and unused jsonpath import

### DIFF
--- a/internal/server/utils.go
+++ b/internal/server/utils.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/itchyny/gojq"
-	"k8s.io/client-go/util/jsonpath"
 )
 
 func InSlice[T comparable](slice []T, el T) bool {
@@ -50,26 +49,6 @@ func CopyResponse(resp *response, upstream *http.Response, customBody []byte, fi
 
 	}
 	return nil
-}
-
-func ParseJsonPath(inputJson []byte, inputJsonPath string) ([]byte, error) {
-	j := jsonpath.New("jsonpath-parser")
-
-	err := j.Parse(inputJsonPath)
-	if err != nil {
-		return nil, err
-	}
-
-	var jsonData interface{}
-	err = json.Unmarshal(inputJson, &jsonData)
-	if err != nil {
-		return nil, err
-	}
-
-	var buf bytes.Buffer
-	err = j.Execute(&buf, jsonData)
-
-	return buf.Bytes(), err
 }
 
 func ParseJQ(inputJson []byte, inputJQ string) (string, error) {


### PR DESCRIPTION
## Summary

- Removes the unused `ParseJsonPath` function from `internal/server/utils.go` (no remaining call sites)
- Removes the `k8s.io/client-go/util/jsonpath` import that was only used by this function

Closes #24

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/server/...` passes