### PR TITLE
fix: add execution timeout and input validation for X-jq header

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -32,7 +32,7 @@ func main() {
 
 	jqConfig := server.JQConfig{
 		MaxExpressionLength: getEnvInt("JQ_MAX_EXPRESSION_LENGTH", 500),
-		ExecutionTimeout:    time.Duration(getEnvInt("JQ_EXECUTION_TIMEOUT_SECONDS", 5)) * time.Second,
+		ExecutionTimeout:    getEnvDuration("JQ_EXECUTION_TIMEOUT", 5*time.Second),
 		MaxResults:          getEnvInt("JQ_MAX_RESULTS", 10000),
 	}
 
@@ -49,6 +49,15 @@ func getEnvInt(key string, defaultVal int) int {
 	if v := os.Getenv(key); v != "" {
 		if i, err := strconv.Atoi(v); err == nil {
 			return i
+		}
+	}
+	return defaultVal
+}
+
+func getEnvDuration(key string, defaultVal time.Duration) time.Duration {
+	if v := os.Getenv(key); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			return d
 		}
 	}
 	return defaultVal

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/openmcp-project/ui-backend/internal/utils"
@@ -29,11 +30,26 @@ func main() {
 	cachingKube := k8s.NewCachingKube(k8s.HttpKube{}, time.Second*30, time.Minute)
 	downstreamKube := k8s.HttpKube{}
 
-	mux := server.NewMiddleware(cachingKube, downstreamKube)
+	jqConfig := server.JQConfig{
+		MaxExpressionLength: getEnvInt("JQ_MAX_EXPRESSION_LENGTH", 500),
+		ExecutionTimeout:    time.Duration(getEnvInt("JQ_EXECUTION_TIMEOUT_SECONDS", 5)) * time.Second,
+		MaxResults:          getEnvInt("JQ_MAX_RESULTS", 10000),
+	}
+
+	mux := server.NewMiddleware(cachingKube, downstreamKube, jqConfig)
 
 	address := ":3000"
 	slog.Info("Starting server", "address", address)
 	if err := http.ListenAndServe(address, mux); err != nil {
 		slog.Error("failed to start server", "err", err)
 	}
+}
+
+func getEnvInt(key string, defaultVal int) int {
+	if v := os.Getenv(key); v != "" {
+		if i, err := strconv.Atoi(v); err == nil {
+			return i
+		}
+	}
+	return defaultVal
 }

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"time"
 
 	"github.com/openmcp-project/ui-backend/pkg/k8s"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -11,9 +12,16 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 )
 
+type JQConfig struct {
+	MaxExpressionLength int
+	ExecutionTimeout    time.Duration
+	MaxResults          int
+}
+
 type shared struct {
 	crateKube      k8s.Kube
 	downstreamKube k8s.Kube
+	jqConfig       JQConfig
 }
 
 type handler func(shared *shared, req *http.Request, res *response) (*response, *HttpError)

--- a/internal/server/handlerCategory.go
+++ b/internal/server/handlerCategory.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"log/slog"
 	"net/http"
@@ -110,10 +111,17 @@ func _categoryHandler(s *shared, req *http.Request, res *response) (*response, *
 	result = append(result, []byte("]")[:]...)
 
 	if data.JQ != "" {
-		resultString, err := ParseJQ(result, data.JQ)
+		if s.jqConfig.MaxExpressionLength > 0 && len(data.JQ) > s.jqConfig.MaxExpressionLength {
+			return nil, NewBadRequestError("jq expression exceeds maximum allowed length")
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), s.jqConfig.ExecutionTimeout)
+		defer cancel()
+
+		resultString, err := ParseJQ(ctx, result, data.JQ, s.jqConfig.MaxResults)
 		if err != nil {
-			slog.Error("failed to parse jq", "err", err)
-			return nil, NewInternalServerError("failed to parse jq")
+			slog.Error("jq execution failed", "err", err)
+			return nil, NewInternalServerError("failed to process jq expression")
 		}
 
 		result = []byte(resultString)

--- a/internal/server/handlerCategory.go
+++ b/internal/server/handlerCategory.go
@@ -111,11 +111,11 @@ func _categoryHandler(s *shared, req *http.Request, res *response) (*response, *
 	result = append(result, []byte("]")[:]...)
 
 	if data.JQ != "" {
-		if s.jqConfig.MaxExpressionLength > 0 && len(data.JQ) > s.jqConfig.MaxExpressionLength {
+		if len(data.JQ) > s.jqConfig.MaxExpressionLength {
 			return nil, NewBadRequestError("jq expression exceeds maximum allowed length")
 		}
 
-		ctx, cancel := context.WithTimeout(context.Background(), s.jqConfig.ExecutionTimeout)
+		ctx, cancel := context.WithTimeout(req.Context(), s.jqConfig.ExecutionTimeout)
 		defer cancel()
 
 		resultString, err := ParseJQ(ctx, result, data.JQ, s.jqConfig.MaxResults)

--- a/internal/server/handlerMain.go
+++ b/internal/server/handlerMain.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -129,7 +130,10 @@ func mainHandler(s *shared, req *http.Request, res *response) (*response, *HttpE
 			return nil, NewInternalServerError("failed to copy response: %v", err)
 		}
 	} else {
-		err := res.buildJqResponse(k8sResp, data)
+		if s.jqConfig.MaxExpressionLength > 0 && len(data.JQ) > s.jqConfig.MaxExpressionLength {
+			return nil, NewBadRequestError("jq expression exceeds maximum allowed length")
+		}
+		err := res.buildJqResponse(k8sResp, data, s.jqConfig)
 		if err != nil {
 			return nil, NewInternalServerError("failed to build jq response: %v", err)
 		}
@@ -179,15 +183,19 @@ func extractRequestData(r *http.Request) (ExtractedRequestData, error) {
 	return rd, nil
 }
 
-func (r *response) buildJqResponse(k8sResp *http.Response, data ExtractedRequestData) error {
+func (r *response) buildJqResponse(k8sResp *http.Response, data ExtractedRequestData, jqConfig JQConfig) error {
 	body, err := io.ReadAll(k8sResp.Body)
 	if err != nil {
 		return errors.Join(errors.New("failed to read api server response"), err)
 	}
 
-	parsedJson, err := ParseJQ(body, data.JQ)
+	ctx, cancel := context.WithTimeout(context.Background(), jqConfig.ExecutionTimeout)
+	defer cancel()
+
+	parsedJson, err := ParseJQ(ctx, body, data.JQ, jqConfig.MaxResults)
 	if err != nil {
-		return errors.Join(errors.New("failed to parse response with jq"), err)
+		slog.Error("jq execution failed", "err", err)
+		return fmt.Errorf("failed to process jq expression")
 	}
 
 	err = CopyResponse(r, k8sResp, []byte(parsedJson), prohibitedResponseHeaders)

--- a/internal/server/handlerMain.go
+++ b/internal/server/handlerMain.go
@@ -130,10 +130,10 @@ func mainHandler(s *shared, req *http.Request, res *response) (*response, *HttpE
 			return nil, NewInternalServerError("failed to copy response: %v", err)
 		}
 	} else {
-		if s.jqConfig.MaxExpressionLength > 0 && len(data.JQ) > s.jqConfig.MaxExpressionLength {
+		if len(data.JQ) > s.jqConfig.MaxExpressionLength {
 			return nil, NewBadRequestError("jq expression exceeds maximum allowed length")
 		}
-		err := res.buildJqResponse(k8sResp, data, s.jqConfig)
+		err := res.buildJqResponse(req.Context(), k8sResp, data, s.jqConfig)
 		if err != nil {
 			return nil, NewInternalServerError("failed to build jq response: %v", err)
 		}
@@ -183,13 +183,13 @@ func extractRequestData(r *http.Request) (ExtractedRequestData, error) {
 	return rd, nil
 }
 
-func (r *response) buildJqResponse(k8sResp *http.Response, data ExtractedRequestData, jqConfig JQConfig) error {
+func (r *response) buildJqResponse(parentCtx context.Context, k8sResp *http.Response, data ExtractedRequestData, jqConfig JQConfig) error {
 	body, err := io.ReadAll(k8sResp.Body)
 	if err != nil {
 		return errors.Join(errors.New("failed to read api server response"), err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), jqConfig.ExecutionTimeout)
+	ctx, cancel := context.WithTimeout(parentCtx, jqConfig.ExecutionTimeout)
 	defer cancel()
 
 	parsedJson, err := ParseJQ(ctx, body, data.JQ, jqConfig.MaxResults)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -6,10 +6,11 @@ import (
 	"github.com/openmcp-project/ui-backend/pkg/k8s"
 )
 
-func NewMiddleware(theCrateKube k8s.Kube, theDownstreamKube k8s.Kube) *http.ServeMux {
+func NewMiddleware(theCrateKube k8s.Kube, theDownstreamKube k8s.Kube, jqConfig JQConfig) *http.ServeMux {
 	shared := &shared{
 		crateKube:      theCrateKube,
 		downstreamKube: theDownstreamKube,
+		jqConfig:       jqConfig,
 	}
 
 	mux := http.NewServeMux()

--- a/internal/server/utils.go
+++ b/internal/server/utils.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -9,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/itchyny/gojq"
-	"k8s.io/client-go/util/jsonpath"
 )
 
 func InSlice[T comparable](slice []T, el T) bool {
@@ -52,53 +52,33 @@ func CopyResponse(resp *response, upstream *http.Response, customBody []byte, fi
 	return nil
 }
 
-func ParseJsonPath(inputJson []byte, inputJsonPath string) ([]byte, error) {
-	j := jsonpath.New("jsonpath-parser")
-
-	err := j.Parse(inputJsonPath)
-	if err != nil {
-		return nil, err
-	}
-
-	var jsonData interface{}
-	err = json.Unmarshal(inputJson, &jsonData)
-	if err != nil {
-		return nil, err
-	}
-
-	var buf bytes.Buffer
-	err = j.Execute(&buf, jsonData)
-
-	return buf.Bytes(), err
-}
-
-func ParseJQ(inputJson []byte, inputJQ string) (string, error) {
+func ParseJQ(ctx context.Context, inputJson []byte, inputJQ string, maxResults int) (string, error) {
 	query, err := gojq.Parse(inputJQ)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("invalid jq expression")
 	}
 
 	var jsonData interface{}
 	err = json.Unmarshal(inputJson, &jsonData)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("invalid JSON input")
 	}
 
-	iter := query.Run(jsonData)
+	iter := query.RunWithContext(ctx, jsonData)
 	var result []string
-	for {
+	for i := 0; i < maxResults; i++ {
 		v, ok := iter.Next()
 		if !ok {
 			break
 		}
 		if err, ok := v.(error); ok {
-			return "", err
+			return "", fmt.Errorf("jq execution failed: %w", err)
 		}
 
 		if b, err := json.Marshal(v); err == nil {
 			result = append(result, string(b))
 		} else {
-			return "", err
+			return "", fmt.Errorf("failed to marshal jq result")
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Adds `context.WithTimeout` to `ParseJQ` using `query.RunWithContext()` to prevent CPU exhaustion from long-running jq expressions
- Caps result iteration at a configurable maximum (default 10,000) to prevent memory exhaustion
- Adds configurable maximum length validation for the `X-jq` header value
- Returns generic error messages to clients instead of leaking internal jq/parsing details
- Removes dead `ParseJsonPath` function and unused `k8s.io/client-go/util/jsonpath` import

### Configuration (env vars)

| Variable | Default | Description |
|---|---|---|
| `JQ_MAX_EXPRESSION_LENGTH` | 500 | Max allowed length of the X-jq header value |
| `JQ_EXECUTION_TIMEOUT_SECONDS` | 5 | Timeout for jq expression execution |
| `JQ_MAX_RESULTS` | 10000 | Max number of result entries from jq iteration |

Closes #23
Closes #24

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/server/...` passes
- [ ] Deploy to staging and verify normal X-jq requests still work
- [ ] Verify that oversized expressions are rejected with 400
- [ ] Verify that long-running expressions (e.g. `[range(100000)]`) are terminated by timeout