### PR TITLE
fix: correct ControlPlaneV2 status.access type to map

### DIFF
--- a/pkg/openmcp/controlplane.go
+++ b/pkg/openmcp/controlplane.go
@@ -23,7 +23,14 @@ func GetControlPlaneV2Kubeconfig(kube k8s.Kube, projectName, workspaceName, cont
 		return k8s.KubeConfig{}, err
 	}
 
-	secretName := cp.Status.Access.OidcOpenmcp.Name
+	ref, ok := cp.Status.Access["oidc_openmcp"]
+	if !ok {
+		ref, ok = cp.Status.Access["default"]
+	}
+	if !ok {
+		return k8s.KubeConfig{}, fmt.Errorf("control-plane v2 has no oidc_openmcp or default access entry")
+	}
+	secretName := ref.Name
 	if secretName == "" {
 		return k8s.KubeConfig{}, fmt.Errorf("control-plane v2 oidc_openmcp secret name is empty")
 	}
@@ -139,13 +146,13 @@ type ControlPlane struct {
 	} `json:"status"`
 }
 
+type LocalObjectReference struct {
+	Name string `json:"name"`
+}
+
 type ControlPlaneV2 struct {
 	k8s.Resource
 	Status struct {
-		Access struct {
-			OidcOpenmcp struct {
-				Name string `json:"name"`
-			} `json:"oidc_openmcp"`
-		} `json:"access"`
+		Access map[string]LocalObjectReference `json:"access"`
 	} `json:"status"`
 }


### PR DESCRIPTION
## Problem

Opening a MCP v2 control plane in the UI returns a 502. The backend logs show:

```
failed to get control plane api config: failed to decode json response:
json: cannot unmarshal string into Go struct field ControlPlaneV2.status
of type struct { Access struct { OidcOpenmcp struct { Name string "json:\"name\"" } ...
```

## Root cause

PR #27 introduced `ControlPlaneV2` with this struct:

```go
Status struct {
    Access struct {
        OidcOpenmcp struct {
            Name string `json:"name"`
        } `json:"oidc_openmcp"`
    } `json:"access"`
} `json:"status"`
```

But the actual CRD schema defines `status.access` as a **map** from OIDC provider name to `LocalObjectReference`:

```
"access": {
  "additionalProperties": { "properties": { "name": { "type": "string" } }, "type": "object" },
  "type": "object"
}
```

The fixed struct field (a Go struct with `json:"oidc_openmcp"`) cannot unmarshal a JSON object with arbitrary string keys — hence the runtime decode error.

## Fix

- Change `ControlPlaneV2.Status.Access` from a fixed nested struct to `map[string]LocalObjectReference`
- Update `GetControlPlaneV2Kubeconfig` to look up by key `"oidc_openmcp"`, falling back to `"default"` (as described in the CRD: _"The default OIDC provider, if configured, uses the name 'default'"_)

## How the 502 is raised

1. Frontend sends `GET /` with `X-mcp-version: v2` header
2. `ui-backend` calls `GetControlPlaneV2Kubeconfig` to fetch the MCP v2 kubeconfig from the crate cluster
3. JSON unmarshal fails → `GetControlPlaneV2Kubeconfig` returns an error
4. Handler logs `"failed to get control plane api config"` and returns HTTP 500
5. NGINX ingress receives 500 and surfaces it to the browser as **502 Bad Gateway**