### PR TITLE
fix: make KUBECONFIG env var optional, fall back to ~/.kube/config

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -22,8 +22,8 @@ func main() {
 
 	kubeconfigPath := os.Getenv(clientcmd.RecommendedConfigPathEnvVar)
 	if kubeconfigPath == "" {
-		slog.Error("env variable '%s' with kubeconfig path not set", clientcmd.RecommendedConfigPathEnvVar)
-		return
+		kubeconfigPath = clientcmd.RecommendedHomeFile
+		slog.Info("env variable not set, using default kubeconfig path", "env", clientcmd.RecommendedConfigPathEnvVar, "path", kubeconfigPath)
 	}
 	go utils.StartListeningOnKubeconfig(ctx, kubeconfigPath)
 


### PR DESCRIPTION
## Summary

- When `KUBECONFIG` is not set, the server no longer exits with an error
- Falls back to `~/.kube/config` (the standard default used by kubectl)
- Logs an info message indicating the fallback path being used

## Test plan

- [ ] Start server without `KUBECONFIG` set — should start normally using `~/.kube/config`
- [ ] Start server with `KUBECONFIG` set to a custom path — should use that path (existing behavior unchanged)