### PR TITLE
feat(connect): support connecting to MCPv2 with custom IdPs

### DIFF
--- a/internal/server/handlerCategory.go
+++ b/internal/server/handlerCategory.go
@@ -48,7 +48,7 @@ func _categoryHandler(s *shared, req *http.Request, res *response) (*response, *
 	var config k8s.KubeConfig
 	if data.ProjectName != "" && data.WorkspaceName != "" && data.McpName != "" {
 		if data.McpVersion == "v2" {
-			config, err = openmcp.GetControlPlaneV2Kubeconfig(s.crateKube, data.ProjectName, data.WorkspaceName, data.McpName, data.CrateAuthorizationToken, crateKubeconfig)
+			config, err = openmcp.GetControlPlaneV2Kubeconfig(s.crateKube, data.ProjectName, data.WorkspaceName, data.McpName, data.McpIdp, data.CrateAuthorizationToken, crateKubeconfig)
 		} else {
 			config, err = openmcp.GetControlPlaneKubeconfig(s.crateKube, data.ProjectName, data.WorkspaceName, data.McpName, data.CrateAuthorizationToken, crateKubeconfig)
 		}

--- a/internal/server/handlerMain.go
+++ b/internal/server/handlerMain.go
@@ -27,6 +27,7 @@ const (
 	jqHeader                              = "X-jq"
 	categoryHeader                        = "X-category"
 	mcpVersionHeader                      = "X-mcp-version"
+	mcpIdpHeader                          = "X-mcp-idp"
 )
 
 var prohibitedRequestHeaders = []string{
@@ -37,6 +38,7 @@ var prohibitedRequestHeaders = []string{
 	workspaceNameHeader,
 	mcpName,
 	mcpVersionHeader,
+	mcpIdpHeader,
 	authorizationHeader,
 	"User-Agent",
 	"Host",
@@ -72,6 +74,7 @@ type ExtractedRequestData struct {
 	JQ                              string
 	Category                        string
 	McpVersion                      string
+	McpIdp                          string
 }
 
 var prohibitedResponseHeaders = []string{"Content-Type", "Content-Length"}
@@ -104,7 +107,7 @@ func mainHandler(s *shared, req *http.Request, res *response) (*response, *HttpE
 		config.SetUserToken(data.CrateAuthorizationToken)
 	} else if data.ProjectName != "" && data.WorkspaceName != "" && data.McpName != "" {
 		if data.McpVersion == "v2" {
-			config, err = openmcp.GetControlPlaneV2Kubeconfig(s.crateKube, data.ProjectName, data.WorkspaceName, data.McpName, data.CrateAuthorizationToken, crateKubeconfig)
+			config, err = openmcp.GetControlPlaneV2Kubeconfig(s.crateKube, data.ProjectName, data.WorkspaceName, data.McpName, data.McpIdp, data.CrateAuthorizationToken, crateKubeconfig)
 		} else {
 			config, err = openmcp.GetControlPlaneKubeconfig(s.crateKube, data.ProjectName, data.WorkspaceName, data.McpName, data.CrateAuthorizationToken, crateKubeconfig)
 		}
@@ -186,6 +189,7 @@ func extractRequestData(r *http.Request) (ExtractedRequestData, error) {
 		JQ:                              r.Header.Get(jqHeader),
 		Category:                        r.Header.Get(categoryHeader),
 		McpVersion:                      r.Header.Get(mcpVersionHeader),
+		McpIdp:                          r.Header.Get(mcpIdpHeader),
 	}
 
 	rd.Headers = r.Header

--- a/pkg/openmcp/controlplane.go
+++ b/pkg/openmcp/controlplane.go
@@ -7,7 +7,7 @@ import (
 	"github.com/openmcp-project/ui-backend/pkg/k8s"
 )
 
-func GetControlPlaneV2Kubeconfig(kube k8s.Kube, projectName, workspaceName, controlPlaneName, crateToken string, crateKubeconfig k8s.KubeConfig) (k8s.KubeConfig, error) {
+func GetControlPlaneV2Kubeconfig(kube k8s.Kube, projectName, workspaceName, controlPlaneName, idpName, crateToken string, crateKubeconfig k8s.KubeConfig) (k8s.KubeConfig, error) {
 	namespace := fmt.Sprintf("project-%s--ws-%s", projectName, workspaceName)
 	path := fmt.Sprintf("/apis/core.open-control-plane.io/v2alpha1/namespaces/%s/controlplanes/%s", namespace, controlPlaneName)
 
@@ -23,16 +23,25 @@ func GetControlPlaneV2Kubeconfig(kube k8s.Kube, projectName, workspaceName, cont
 		return k8s.KubeConfig{}, err
 	}
 
-	ref, ok := cp.Status.Access["oidc_openmcp"]
-	if !ok {
+	// V2 exposes one access entry per IdP, keyed `oidc_<providerName>`. The system IdP is
+	// `oidc_openmcp` (used when no idp is selected); a custom IdP is `oidc_<idpName>`.
+	accessKey := "oidc_openmcp"
+	if idpName != "" {
+		accessKey = "oidc_" + idpName
+	}
+
+	ref, ok := cp.Status.Access[accessKey]
+	if !ok && idpName == "" {
+		// Legacy v2 control planes expose only a `default` access entry. Keep the
+		// fallback for the no-idp path; an explicitly selected idp must fail loudly.
 		ref, ok = cp.Status.Access["default"]
 	}
 	if !ok {
-		return k8s.KubeConfig{}, fmt.Errorf("control-plane v2 has no oidc_openmcp or default access entry")
+		return k8s.KubeConfig{}, fmt.Errorf("control-plane v2 has no %q access entry", accessKey)
 	}
 	secretName := ref.Name
 	if secretName == "" {
-		return k8s.KubeConfig{}, fmt.Errorf("control-plane v2 oidc_openmcp secret name is empty")
+		return k8s.KubeConfig{}, fmt.Errorf("control-plane v2 %q secret name is empty", accessKey)
 	}
 
 	secret := k8s.Secret{}


### PR DESCRIPTION
Closes openmcp-project/backlog#457

Adds custom IdP support for Control Planes.

Frontend: https://github.com/openmcp-project/ui-frontend/pull/736