### PR TITLE
chore(deps): removes renovate config which is in org presets

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>openmcp-project/.github:renovate-config",
+    "group:allNonMajor"
+  ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", "group:allNonMajor"]
-}


### PR DESCRIPTION
**What this PR does / why we need it**:

Moves `renovate.json` to `.github/renovate.json` and references the new org-level preset
- `extends`: recommended + best-practices + openssf-scorecard + pinGitHubActionDigests + rebaseStalePrs
- `postUpdateOptions`: gomodTidy
- golang `rangeStrategy: bump` rule
- `openmcp-project/build` group rule
- `openmcp-project` Go dependencies grouped into one PR

see org-level preset in [openmcp-project/renovate-config.json](https://github.com/openmcp-project/.github/blob/main/renovate-config.json)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```other dependency

```