### PR TITLE
fix: eliminate connection and memory leaks in api server proxy

### DIFF
--- a/internal/server/handlerCategory.go
+++ b/internal/server/handlerCategory.go
@@ -85,6 +85,25 @@ func _categoryHandler(s *shared, req *http.Request, res *response) (*response, *
 	}
 
 	resultData := make([][]byte, 0)
+	// fetchResource performs a single api server request and returns the body,
+	// closing the response body via defer so it is released every iteration
+	// (a bare defer in the loop below would accumulate until function return).
+	fetchResource := func(apiReq k8s.Request) ([]byte, *HttpError) {
+		k8sResp, err := s.downstreamKube.RequestApiServerRaw(apiReq, config)
+		if err != nil {
+			slog.Error("failed to get managed resources", "err", err)
+			return nil, NewInternalServerError("failed to get managed resources")
+		}
+		defer k8sResp.Body.Close()
+
+		body, err := io.ReadAll(k8sResp.Body)
+		if err != nil {
+			slog.Error("failed to read data from response", "err", err)
+			return nil, NewInternalServerError("failed to read data from response")
+		}
+		return body, nil
+	}
+
 	for _, category := range categories {
 		for _, version := range category.Versions {
 			for _, resource := range version.Resources {
@@ -94,19 +113,12 @@ func _categoryHandler(s *shared, req *http.Request, res *response) (*response, *
 					Headers: data.Headers,
 				}
 
-				k8sResp, err := s.downstreamKube.RequestApiServerRaw(apiReq, config)
-				if err != nil {
-					slog.Error("failed to get managed resources", "err", err)
-					return nil, NewInternalServerError("failed to get managed resources")
+				body, httpErr := fetchResource(apiReq)
+				if httpErr != nil {
+					return nil, httpErr
 				}
 
-				data, err := io.ReadAll(k8sResp.Body)
-				if err != nil {
-					slog.Error("failed to read data from response", "err", err)
-					return nil, NewInternalServerError("failed to read data from response")
-				}
-
-				resultData = append(resultData, data)
+				resultData = append(resultData, body)
 			}
 		}
 	}

--- a/pkg/k8s/apiserver.go
+++ b/pkg/k8s/apiserver.go
@@ -3,9 +3,11 @@ package k8s
 import (
 	"bufio"
 	"bytes"
+	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"hash/fnv"
@@ -14,11 +16,68 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"sync"
 	"time"
 
 	"github.com/patrickmn/go-cache"
 	"k8s.io/api/apidiscovery/v2beta1"
 )
+
+// maxCacheableResponseBytes caps the size of a response body that the response
+// cache will store. Larger responses are served through but not cached to keep
+// the cache from growing unbounded.
+const maxCacheableResponseBytes = 1 << 20 // 1MiB
+
+// requestTimeout bounds how long a single api server request may take, so a hung
+// api server cannot pin a connection (and its goroutine) forever.
+const requestTimeout = 30 * time.Second
+
+// maxTransportCacheEntries bounds the number of cached transports. When the
+// limit is exceeded an arbitrary entry is evicted and its idle connections are
+// closed so eviction does not re-leak connection pools.
+const maxTransportCacheEntries = 128
+
+// transportCache is a bounded, concurrency-safe cache of *http.Transport keyed
+// by a hash of the TLS-affecting inputs. Reusing transports recovers connection
+// pooling and keep-alives that would otherwise leak on every request.
+type transportCache struct {
+	mu      sync.Mutex
+	entries map[string]*http.Transport
+	limit   int
+}
+
+func newTransportCache(limit int) *transportCache {
+	return &transportCache{
+		entries: make(map[string]*http.Transport),
+		limit:   limit,
+	}
+}
+
+// getOrCreate returns the cached transport for key, or builds one with build and
+// stores it. When the cache is full an existing entry is evicted and its idle
+// connections are closed.
+func (c *transportCache) getOrCreate(key string, build func() *http.Transport) *http.Transport {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if t, ok := c.entries[key]; ok {
+		return t
+	}
+
+	if len(c.entries) >= c.limit {
+		for k, evicted := range c.entries {
+			delete(c.entries, k)
+			evicted.CloseIdleConnections()
+			break
+		}
+	}
+
+	t := build()
+	c.entries[key] = t
+	return t
+}
+
+var sharedTransportCache = newTransportCache(maxTransportCacheEntries)
 
 func RequestApiServer(kube Kube, request Request, config KubeConfig, result interface{}) error {
 	if request.Headers == nil {
@@ -136,10 +195,33 @@ func (HttpKube) RequestApiServerRaw(request Request, config KubeConfig) (*http.R
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", user.User.Token))
 	}
 
+	// Build a cache key from all TLS-affecting inputs. The bearer token is
+	// deliberately excluded: it is a per-request header, not transport-level
+	// material. sha256 is used (not fnv) because a collision here would serve a
+	// transport built for a different cluster - a security issue.
+	keyHash := sha256.New()
+	keyHash.Write([]byte(cluster.Cluster.Server))
+	keyHash.Write([]byte{0})
+	keyHash.Write([]byte(cluster.Cluster.CertificateAuthorityData))
+	keyHash.Write([]byte{0})
+	keyHash.Write([]byte(user.User.ClientCertificateData))
+	keyHash.Write([]byte{0})
+	keyHash.Write([]byte(user.User.ClientKeyData))
+	transportKey := hex.EncodeToString(keyHash.Sum(nil))
+
+	transport := sharedTransportCache.getOrCreate(transportKey, func() *http.Transport {
+		return &http.Transport{
+			TLSClientConfig:     &tlsConfig,
+			MaxIdleConns:        100,
+			MaxIdleConnsPerHost: 10,
+			IdleConnTimeout:     90 * time.Second,
+			ForceAttemptHTTP2:   true,
+		}
+	})
+
 	client := &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: &tlsConfig,
-		},
+		Transport: transport,
+		Timeout:   requestTimeout,
 	}
 
 	slog.Debug("requesting api server", "method", request.Method, "host", config.Clusters[0].Cluster.Server, "path", request.Path)
@@ -231,7 +313,7 @@ func (c cachingKube) RequestApiServerRaw(request Request, config KubeConfig) (*h
 	// this key is a unique identifier for the request - however, it is not guaranteed to be unique
 	key := fmt.Sprintf("%s %s %s %s %s %v", request.Method, request.Path, request.Body, request.Headers, request.Query, config)
 
-	h := fnv.New32()
+	h := fnv.New128()
 	_, err := h.Write([]byte(key))
 	if err != nil {
 		return nil, err
@@ -256,9 +338,16 @@ func (c cachingKube) RequestApiServerRaw(request Request, config KubeConfig) (*h
 	}
 	response, err := httputil.DumpResponse(res, true)
 	if err != nil {
+		// DumpResponse consumed/failed on res.Body; the caller receives an error
+		// and will never close it, so close it here to avoid leaking it.
+		res.Body.Close()
 		return nil, err
 	}
-	c.cache.Set(hashedKey, &response, cache.DefaultExpiration)
+	// Only cache responses up to a bounded size so the cache cannot grow
+	// unbounded with large bodies (it is otherwise TTL-eviction only).
+	if len(response) <= maxCacheableResponseBytes {
+		c.cache.Set(hashedKey, &response, cache.DefaultExpiration)
+	}
 	return res, nil
 }
 


### PR DESCRIPTION
## Why

Three confirmed resource/memory leaks in the api server proxy. Under load they exhaust sockets/file descriptors and grow memory: a fresh `http.Transport` (and its connection pool) was built per request, response bodies were leaked in the category handler loop, and the response cache was unbounded.

## What changed

- **pkg/k8s/apiserver.go — reuse transports.** Replace the per-request `http.Transport` with a bounded, mutex-guarded package-level cache keyed by `sha256(server + CA data + client cert data + client key data)` (NUL-separated; bearer token deliberately excluded - it is a per-request header, not transport-level). Cache hit reuses the transport so keep-alive pooling is restored. On eviction the dropped transport's `CloseIdleConnections()` is called so eviction cannot re-leak. Transports use `MaxIdleConns=100`, `MaxIdleConnsPerHost=10`, `IdleConnTimeout=90s`, `ForceAttemptHTTP2=true`. Client gains a 30s `Timeout` (via `client.Timeout`, not a context, to avoid cancelling the body mid-read) so a hung api server cannot pin a connection forever.
- **internal/server/handlerCategory.go — close bodies in loop.** Extract the per-iteration request into a `fetchResource` closure with `defer k8sResp.Body.Close()`, so the body is released every iteration on both the success and the ReadAll-error path (previously never closed - one leaked body/connection per resource, inside a triple-nested loop).
- **pkg/k8s/apiserver.go — bound the response cache.** Close `res.Body` on the `httputil.DumpResponse` error path (was orphaned, caller got `nil,err` and never closed it). Skip caching responses larger than 1MiB so the TTL-only cache cannot grow unbounded. Widen the response-cache hash from fnv32 to fnv128 to reduce collisions.

## Review

Reviewed by two independent agents (strict security+leak, and code design) - both approve. Key composition, body-close on all paths, and eviction-under-lock verified.

## Follow-ups (out of scope, pre-existing)

- Response-cache key formats `request.Body` (an `io.Reader`) as a pointer, so non-GET requests with identical method/path/query can collide. Recommend excluding body or caching GETs only.
- `pkg/k8s` has no tests; transport key derivation + cache eviction are trivially unit-testable.
- `InsecureSkipTLSVerify` in the kubeconfig is parsed but never applied to the TLS config.
