### PR TITLE
feat: add GET /healthz endpoint for Kubernetes probes

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -15,6 +15,11 @@ func NewMiddleware(theCrateKube k8s.Kube, theDownstreamKube k8s.Kube, jqConfig J
 
 	mux := http.NewServeMux()
 
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	})
 	mux.HandleFunc("/managed", defaultHandler(shared, managedHandler))
 	mux.HandleFunc("/c/", defaultHandler(shared, categoryHandler))
 	mux.HandleFunc("/", defaultHandler(shared, mainHandler))


### PR DESCRIPTION
## Summary
- Adds `GET /healthz` route to the Go HTTP mux returning `{"status":"ok"}` 200
- Used by the readiness and liveness probes in the `ui-environments` deployment manifest

## Test plan
- [ ] `curl http://localhost:3000/healthz` returns `{"status":"ok"}` 200
- [ ] Pod reaches `Ready` state with probes configured in companion `ui-environments` PR